### PR TITLE
Remove DeprecationWarning

### DIFF
--- a/src/App.coffee
+++ b/src/App.coffee
@@ -91,7 +91,7 @@ class App
       ' ' + tempInputFile
     out = @_exec command, cwd: fullOutDirName
     @logger.error out.stderr if out.status > 0
-    @_fs.unlink tempInputFile
+    @_fs.unlinkSync tempInputFile
 
 
   ###*


### PR DESCRIPTION
Using the async unlink method result in a `DeprecationWarning: Calling an asynchronous function without callback is deprecated.` at least in node 8.

Using a the Sync version fixes this.