### PR TITLE
Dev

### DIFF
--- a/src/App.coffee
+++ b/src/App.coffee
@@ -2,10 +2,10 @@ class App
 
   # @link http://hackage.haskell.org/package/pandoc For options description
   @outputTypesAdd = [
-    'gfm' # use GitHub markdown variant
+    'markdown_github' # use GitHub markdown variant
     'blank_before_header' # insert blank line before header
 #    'mmd_link_attributes' # use MD syntax for images and links instead of HTML
-    'link_attributes' # use MD syntax for images and links instead of HTML
+#    'link_attributes' # use MD syntax for images and links instead of HTML
   ]
 
   @outputTypesRemove = [

--- a/src/App.coffee
+++ b/src/App.coffee
@@ -2,7 +2,7 @@ class App
 
   # @link http://hackage.haskell.org/package/pandoc For options description
   @outputTypesAdd = [
-    'markdown_github' # use GitHub markdown variant
+    'gfm' # use GitHub markdown variant
     'blank_before_header' # insert blank line before header
 #    'mmd_link_attributes' # use MD syntax for images and links instead of HTML
 #    'link_attributes' # use MD syntax for images and links instead of HTML

--- a/src/App.coffee
+++ b/src/App.coffee
@@ -2,7 +2,7 @@ class App
 
   # @link http://hackage.haskell.org/package/pandoc For options description
   @outputTypesAdd = [
-    'markdown_github' # use GitHub markdown variant
+    'gfm' # use GitHub markdown variant
     'blank_before_header' # insert blank line before header
 #    'mmd_link_attributes' # use MD syntax for images and links instead of HTML
     'link_attributes' # use MD syntax for images and links instead of HTML


### PR DESCRIPTION
Accorging to their [docs](https://pandoc.org/MANUAL.html), "markdown_github" is deprecated in favour of "gfm".

This produced various improvements for me when using the output as a git wiki.