### PR TITLE
Add an option to use Docker to run the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:current-slim
+
+WORKDIR /var/app
+RUN mkdir -p /var/app
+COPY . /var/app/
+
+RUN apt-get update -qq \
+    && apt-get install -y pandoc \
+    && npm install
+
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ In the converter's directory:
 npm run start <pathResource> <pathResult>
 ```
 
+### Using the Docker image
+
+All you need installed on your computer is Docker. Then use the following command to run you conversion (this example
+shares the current directory - `$PWD` on linux and Mac - and convert from the export subdirectory to the docs directory):
+
+```
+docker run -it -v $PWD:$PWD meridius/confluence-to-markdown npm run start $PWD/export $PWD/docs
+```
 
 ### Parameters
 


### PR DESCRIPTION
Hi,

For people like me who don't want to have to install npm and all the packages around it it's pretty convenient to have a Docker image that you can drop afterwards. This has become a very common way to distribute applications.

In this PR I've added a Dockerfile for that purpose and a section on the documentation on how to use it.

If you want to test it you can use my image `aerostitch/confluence-to-markdown:latest` in the example.

Note that you will probably want to setup an automated build on Docker hub to have it always up-to-date.

Joseph