### PR TITLE
fix: Use `--markdown-headings=atx` instead of `--atx-headers`

### DIFF
--- a/src/App.coffee
+++ b/src/App.coffee
@@ -12,7 +12,7 @@ class App
   ]
 
   @extraOptions = [
-    '--atx-headers' # Setext-style headers (underlined) | ATX-style headers (prefixed with hashes)
+    '--markdown-headings=atx' # Setext-style headers (underlined) | ATX-style headers (prefixed with hashes)
   ]
 
   ###*


### PR DESCRIPTION
to please Pandoc 2.11.3.2 as it warns for atx headers.